### PR TITLE
通知機能を実装中

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -4,7 +4,8 @@ class TasksController < ApplicationController
   before_action :set_qiita_user_id, only: %i[ index show new edit ]
 
   def index
-    @tasks = Task.all.includes(:user).order(created_at: :desc)
+    @tasks = Task.where(user_id: current_user.id).includes(:user).order("created_at DESC")
+
     @articles = Article.all.includes(:task).order(created_at: :desc)
 
     @qiita = @articles.map(&:qiita_id)
@@ -79,7 +80,10 @@ class TasksController < ApplicationController
   end
 
   def today
-    @tasks = Task.doing_today.includes(:user).order(created_at: :desc)
+    @task = Task.where(user_id: current_user.id).includes(:user).order("created_at DESC")
+    @tasks = @task.doing_today
+
+
     @articles = Article.all.includes(:task).order(created_at: :desc)
 
     @qiita = @articles.map(&:qiita_id)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,7 +8,16 @@ class UsersController < ApplicationController
   def update
     @user = User.find(params[:id])
     @user.id = current_user.id
+
+    @notification_at_1 = user_params[:notification_at_1]
+    @notification_at_2 = user_params[:notification_at_2]
+    @notification_at_3 = user_params[:notification_at_3]
+    @notification_all = "#{@notification_at_1},#{@notification_at_2},#{@notification_at_3}"
+    @notification_at = @notification_all.split(',')
+
     if @user.update(user_params)
+      @user.notification_at = @notification_at
+      @user.save
       redirect_to edit_user_path(@user), success: t('defaults.message.user_info_updated')
     else
       flash.now['danger'] = t('defaults.message.not_user_info_updated')
@@ -19,6 +28,6 @@ class UsersController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(:qiita_user_id, :default_task_cycle, :default_repeat_count)
+    params.require(:user).permit(:qiita_user_id, :default_task_cycle, :default_repeat_count, :notification_at_1, :notification_at_2, :notification_at_3)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,10 +4,12 @@ class UsersController < ApplicationController
     @user = User.find(params[:id])
     @user.id = current_user.id
     @notifications = @user.notification_at
-    @notification = JSON.parse(@notifications)
-    @notification_at_1 = @notification[0]
-    @notification_at_2 = @notification[1]
-    @notification_at_3 = @notification[2]
+    if @notifications.present?
+      @notification = JSON.parse(@notifications)
+      @notification_at_1 = @notification[0]
+      @notification_at_2 = @notification[1]
+      @notification_at_3 = @notification[2]
+    end
   end
 
 def update

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,15 +3,20 @@ class UsersController < ApplicationController
   def edit
     @user = User.find(params[:id])
     @user.id = current_user.id
+    @notifications = @user.notification_at
+    @notification = JSON.parse(@notifications)
+    @notification_at_1 = @notification[0]
+    @notification_at_2 = @notification[1]
+    @notification_at_3 = @notification[2]
   end
 
-  def update
+def update
     @user = User.find(params[:id])
     @user.id = current_user.id
 
-    @notification_at_1 = user_params[:notification_at_1]
-    @notification_at_2 = user_params[:notification_at_2]
-    @notification_at_3 = user_params[:notification_at_3]
+    @notification_at_1 = params[:notification_at_1]
+    @notification_at_2 = params[:notification_at_2]
+    @notification_at_3 = params[:notification_at_3]
     @notification_all = "#{@notification_at_1},#{@notification_at_2},#{@notification_at_3}"
     @notification_at = @notification_all.split(',')
 
@@ -28,6 +33,6 @@ class UsersController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(:qiita_user_id, :default_task_cycle, :default_repeat_count, :notification_at_1, :notification_at_2, :notification_at_3)
+    params.require(:user).permit(:qiita_user_id, :default_task_cycle, :default_repeat_count)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,8 @@ class User < ApplicationRecord
 
   has_many :tasks, dependent: :destroy
 
+  validates :notification_at, length: { maximum: 27 }
+
   def own?(object)
     object.user_id == id
   end

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -29,21 +29,21 @@
               <div class= form-group >
                 <div class="m-3">
                   <label class="form-label" for="user_notification_at">通知時刻1</label>
-                  <input type="text" name="user[notification_at_1]" id="user_notification_at_1" class="form-control" >
+                  <input type="time" name="notification_at_1" id="user_notification_at_1" value =<%= @notification_at_1 %> step="300" class="form-control" >
                 </div>
               </div>
 
               <div class= form-group >
                 <div class="m-3">
                   <label class="form-label" for="user_notification_at">通知時刻2</label>
-                  <input type="text" name="user[notification_at_2]" id="user_notification_at_2" class="form-control" >
+                  <input type="time" name="notification_at_2" id="user_notification_at_2" value =<%= @notification_at_2 %> step="300" class="form-control" >
                 </div>
               </div>
 
               <div class= form-group >
                 <div class="m-3">
                   <label class="form-label" for="user_notification_at">通知時刻3</label>
-                  <input type="text" name="user[notification_at_3]" id="user_notification_at_3" class="form-control" >
+                  <input type="time" name="notification_at_3" id="user_notification_at_3" value =<%= @notification_at_3 %> step="300" class="form-control" >
                 </div>
               </div>
 

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -26,6 +26,27 @@
                 </div>
               </div>
 
+              <div class= form-group >
+                <div class="m-3">
+                  <label class="form-label" for="user_notification_at">通知時刻1</label>
+                  <input type="text" name="user[notification_at_1]" id="user_notification_at_1" class="form-control" >
+                </div>
+              </div>
+
+              <div class= form-group >
+                <div class="m-3">
+                  <label class="form-label" for="user_notification_at">通知時刻2</label>
+                  <input type="text" name="user[notification_at_2]" id="user_notification_at_2" class="form-control" >
+                </div>
+              </div>
+
+              <div class= form-group >
+                <div class="m-3">
+                  <label class="form-label" for="user_notification_at">通知時刻3</label>
+                  <input type="text" name="user[notification_at_3]" id="user_notification_at_3" class="form-control" >
+                </div>
+              </div>
+
               <div class="text-center">
                 <div class="m-3">
                   <%= f.submit nil, class: 'btn btn-primary' %>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -12,6 +12,7 @@ ja:
         qiita_user_id: 'Qiitaユーザ名'
         default_task_cycle: '繰り返し周期'
         default_repeat_count: '繰り返し回数'
+        notification_at: '通知時刻'
       task:
         name: 'タスク名'
         body: '備考'

--- a/db/migrate/20220330085516_add_notification_at_to_users.rb
+++ b/db/migrate/20220330085516_add_notification_at_to_users.rb
@@ -1,0 +1,5 @@
+class AddNotificationAtToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :notification_at, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_28_125536) do
+ActiveRecord::Schema.define(version: 2022_03_30_085516) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -71,6 +71,7 @@ ActiveRecord::Schema.define(version: 2022_03_28_125536) do
     t.string "qiita_user_id"
     t.integer "default_task_cycle"
     t.integer "default_repeat_count"
+    t.string "notification_at"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true


### PR DESCRIPTION
## 変更の概要

usersテーブルに通知時刻をnotification_atカラム、string型を用意、
時刻1、時効2、時効3のように保存したい。


## なぜこの変更をするのか

アカウント設定ページから時刻1、時効2、時刻3を入力して「更新」すると以下のエラーが発生してしまう。
`ActiveModel::UnknownAttributeError in UsersController#update
unknown attribute 'notification_at_1' for User.
 `

## やったこと

* [x] やったこと
*  usersテーブルにnotification_atカラムをstring型で追加
* アカウント設定ページに時刻1、時刻2、時刻3を送信できるフォームを用意した
*  フォームから受け取った3つのカラム（時刻）をsplitを使い、3つのカラムをカンマ区切りに一つにまとめた
*  タスク一覧機能の修正：　タスク一覧ページ・今日ページでログイン中のユーザーの記事のみ表示するように実装
* [ ] やっていること
* フォームから受け取った3つのカラムをnotification_atカラムに保存
* `@user.update(user_params)`の際にActiveModel::UnknownAttributeErrorになるので対処


## 変更内容

* 実装前
![新規メモ](https://user-images.githubusercontent.com/83563470/161141426-15ae2ca6-fd7b-4b05-b0c8-a2ae8e85d9bd.jpeg)

* 実装後
![新規メモ](https://user-images.githubusercontent.com/83563470/161141492-5dfb713b-6836-4667-9a63-bcbf1202f483.jpeg)

## 確認手順

1. ゲストログイン
2. ヘッダーのアカウント設定にアクセス
3. 通知時刻を全て入力して更新ボタンをクリック
4. usersコントローラーのupdateメソッドが発火
5. ActiveModel::UnknownAttributeErrorが発生


## 課題

* 悩んでいること
* とくにレビューしてほしいところ
* usersコントローラーのupdate処理
* ストロングパラメータを使用しないでparamsを使うとは？
* 3つのカラムをカンマ区切りに一つにまとめる処理は実装できているのか？

## 備考

タスク一覧ページ・今日ページの修正をこのブランチで行ってしまった。

現状；　全てのユーザーのタスクが表示されていた。
修正；　ログイン中のユーザのタスクのみ表示するようにした。